### PR TITLE
Improved raft backend template: Added a condition to handle external …

### DIFF
--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -29,7 +29,7 @@ storage "raft" {
   {% endif %}
   {% if not vault_raft_cloud_auto_join_exclusive %}
   {% for raft_peer in vault_raft_cluster_members | rejectattr('peer', 'equalto', inventory_hostname) %}
-    {% if not (vault_tls_disable | bool) %}
+    {% if not (vault_tls_disable | bool) and vault_tls_client_ca_file != "" %}
   retry_join {
     leader_api_addr = "{{ raft_peer.api_addr }}"
     {% if vault_raft_leader_tls_servername is defined %}


### PR DESCRIPTION
…non-controllable CAs like Let's Encrypt where we don't have access to vault_tls_client_ca_file, but still need TLS encryption for clients' connections in listeners. This should resolve any issues related to TLS encryption in such scenarios.